### PR TITLE
Fix request headers

### DIFF
--- a/go/bridge/bridge.go
+++ b/go/bridge/bridge.go
@@ -12,12 +12,12 @@ import (
 )
 
 type Request struct {
-	Host     string            `json:"host"`
-	Path     string            `json:"path"`
-	Method   string            `json:"method"`
-	Headers  map[string]string `json:"headers"`
-	Encoding string            `json:"encoding,omitempty"`
-	Body     string            `json:"body"`
+	Host     string              `json:"host"`
+	Path     string              `json:"path"`
+	Method   string              `json:"method"`
+	Headers  map[string][]string `json:"headers"`
+	Encoding string              `json:"encoding,omitempty"`
+	Body     string              `json:"body"`
 }
 
 type Response struct {
@@ -65,9 +65,10 @@ func Serve(handler http.Handler, req *Request) (res Response, err error) {
 		return
 	}
 
-	for k, v := range req.Headers {
-		r.Header.Add(k, v)
-		switch strings.ToLower(k) {
+	for k, vv := range req.Headers {
+		for _, v := range vv {
+			r.Header.Add(k, v)
+			switch strings.ToLower(k) {
 			case "host":
 				// we need to set `Host` in the request
 				// because Go likes to ignore the `Host` header
@@ -79,6 +80,7 @@ func Serve(handler http.Handler, req *Request) (res Response, err error) {
 			case "x-forwarded-for":
 			case "x-real-ip":
 				r.RemoteAddr = v
+			}
 		}
 	}
 

--- a/go/bridge/bridge_test.go
+++ b/go/bridge/bridge_test.go
@@ -14,6 +14,7 @@ type HttpHandler struct {
 
 func (h *HttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("X-Foo", "bar")
+	w.Header().Add("X-Foo", "baz")
 	w.WriteHeader(404)
 	w.Write([]byte("test"))
 }
@@ -24,7 +25,7 @@ func TestServe(t *testing.T) {
 		"test.com",
 		"/path?foo=bar",
 		"POST",
-		map[string]string{"Content-Length": "1", "X-Foo": "bar"},
+		map[string][]string{"Content-Length": []string{"1"}, "X-Foo": []string{"bar"}},
 		"",
 		"a",
 	}


### PR DESCRIPTION
Fixes an error when request has multiple headers with the same key but different value.

```
curl -i -H "Foo: bar" -H "Foo: baz"  https://vercel-bug-repro.vercel.app/
```

```
json: cannot unmarshal array into Go struct field Request.headers of type string: UnmarshalTypeError
```