### PR TITLE
ensure `RequestURI` exists on marshaled requests

### DIFF
--- a/go/bridge/bridge.go
+++ b/go/bridge/bridge.go
@@ -13,12 +13,13 @@ import (
 )
 
 type Request struct {
-	Host     string                     `json:"host"`
-	Path     string                     `json:"path"`
-	Method   string                     `json:"method"`
-	Headers  map[string]ReqHeaderValues `json:"headers"`
-	Encoding string                     `json:"encoding,omitempty"`
-	Body     string                     `json:"body"`
+	Host       string                     `json:"host"`
+	Path       string                     `json:"path"`
+	Method     string                     `json:"method"`
+	Headers    map[string]ReqHeaderValues `json:"headers"`
+	Encoding   string                     `json:"encoding,omitempty"`
+	Body       string                     `json:"body"`
+	RequestURI string
 }
 
 type ReqHeaderValues []string
@@ -78,6 +79,7 @@ func Serve(handler http.Handler, req *Request) (res Response, err error) {
 	}
 
 	r, err := http.NewRequest(req.Method, req.Path, bytes.NewReader(body))
+
 	if err != nil {
 		return
 	}
@@ -141,6 +143,8 @@ func handler(event events.APIGatewayProxyRequest) (res Response, err error) {
 func ParseJsonIntoRequest(body string) (Request, error) {
 	var req Request
 	err := json.Unmarshal([]byte(body), &req)
+	req.RequestURI = req.Path
+
 	return req, err
 }
 

--- a/go/bridge/bridge_test.go
+++ b/go/bridge/bridge_test.go
@@ -28,6 +28,7 @@ func TestServe(t *testing.T) {
 		map[string]ReqHeaderValues{"Content-Length": ReqHeaderValues{"1"}, "X-Foo": ReqHeaderValues{"bar"}},
 		"",
 		"a",
+		"/path?foo=bar",
 	}
 	res, err := Serve(h, req)
 	if err != nil {
@@ -67,7 +68,7 @@ func TestParseJsonIntoRequest(t *testing.T) {
 		  "x-vercel-forwarded-for": "0.0.0.0",
 		  "x-vercel-id": "dev1::pkmmp-1636755907234-8ee8499e420c"
 		},
-		"path": "/",
+		"path": "/about",
 		"host": "example.com"
 	  }`
 	req, err := ParseJsonIntoRequest(body)
@@ -76,6 +77,14 @@ func TestParseJsonIntoRequest(t *testing.T) {
 		fmt.Printf("err: %v\n", err)
 		t.Fail()
 	}
+
+	if req.Path != "/about" {
+		t.Errorf("Unexpected Path: %s", req.RequestURI)
+	}
+	if req.RequestURI != "/about" {
+		t.Errorf("Unexpected RequestURI: %s", req.RequestURI)
+	}
+
 	if req.Host != "example.com" {
 		t.Errorf("Unexpected host: %s", req.Host)
 	}


### PR DESCRIPTION
When using a `request` provided by `go-bridge`, the `RequestURI` property is missing. This happens in deployed Go serverless functions, but works locally with `vc dev`.

Go documentation says that `request.RequestURI` is the raw value from the HTTP message `request-line` whereas `request.URL` is a normalized value.

This PR copies the value from `request.Path` into `request.RequestURI`.

---

Example failing serverless function `api/example.go`:

```
package api

import (
  "fmt"
  "net/http"
)

func ExampleHandler(w http.ResponseWriter, r *http.Request) {
  fmt.Fprintf(w, "URL=%s ; RequestURI=%s", r.URL, r.RequestURI)
}
```

In `vc dev`, the result is: `URL=/api/example ; RequestURI=/api/example`

In a deployment, the result is: `URL=/api/example ; RequestURI=`