### PR TITLE
Propagate RequestURI

### DIFF
--- a/go/bridge/bridge.go
+++ b/go/bridge/bridge.go
@@ -80,6 +80,10 @@ func Serve(handler http.Handler, req *Request) (res Response, err error) {
 
 	r, err := http.NewRequest(req.Method, req.Path, bytes.NewReader(body))
 
+	// NewRequest does not populate	RequestURI,
+	// but some go modules still expect this to exist
+	r.RequestURI = r.URL.Path
+
 	if err != nil {
 		return
 	}

--- a/go/bridge/bridge.go
+++ b/go/bridge/bridge.go
@@ -81,7 +81,7 @@ func Serve(handler http.Handler, req *Request) (res Response, err error) {
 	r, err := http.NewRequest(req.Method, req.Path, bytes.NewReader(body))
 
 	// NewRequest does not populate	RequestURI,
-	// but some go modules still expect this to exist
+	// but some Go modules still expect this to exist
 	r.RequestURI = r.URL.Path
 
 	if err != nil {

--- a/go/bridge/bridge_test.go
+++ b/go/bridge/bridge_test.go
@@ -43,7 +43,7 @@ func TestServe(t *testing.T) {
 		t.Fail()
 	}
 
-	if res.Headers["X-RequestURI"][0] != "/path" {
+	if res.Headers["X-Requesturi"][0] != "/path" {
 		fmt.Printf("expected response header \"X-RequestURI\" == \"%s\"\n", res.Headers["X-RequestURI"][0])
 		t.Fail()
 	}

--- a/go/bridge/bridge_test.go
+++ b/go/bridge/bridge_test.go
@@ -13,6 +13,8 @@ type HttpHandler struct {
 }
 
 func (h *HttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("X-RequestURI", r.RequestURI)
+
 	w.Header().Add("X-Foo", "bar")
 	w.Header().Add("X-Foo", "baz")
 	w.WriteHeader(404)
@@ -38,6 +40,11 @@ func TestServe(t *testing.T) {
 		fmt.Printf("status code: %d\n", res.StatusCode)
 		fmt.Printf("header: %v\n", res.Headers)
 		fmt.Printf("base64 body: %s\n", res.Body)
+		t.Fail()
+	}
+
+	if res.Headers["X-RequestURI"][0] != "/path" {
+		fmt.Printf("expected response header \"X-RequestURI\" == \"%s\"\n", res.Headers["X-RequestURI"][0])
 		t.Fail()
 	}
 


### PR DESCRIPTION
A [previous PR](https://github.com/vercel/go-bridge/pull/5) made sure that `RequestURI` was unmarshaled, from the request. This PR ensures that the value propagates to the request we present to the user's Go endpoint handler.

This should resolve an issue where some Go libraries assuming `RequestURI` exists, like https://github.com/swaggo
